### PR TITLE
Improve reliability of agent generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains a simple Go backend exposing APIs for running various c
 - `/api/test/results` – list of submissions received
 - `/api/stroop` – Stroop word/color test
 - `/api/math` – simple arithmetic questions
+- `/api/sequence` – numeric series reasoning task
+- `/api/iq` – approximate IQ estimation from test scores
 - `/api/pool` – generate a randomized pool of tests for a session
 
 All endpoints return JSON data and support CORS for local development.

--- a/handlers/iq.go
+++ b/handlers/iq.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/nicconuti/cognitive-api/utils"
+)
+
+// IQRequest represents the incoming data for IQ estimation.
+type IQRequest struct {
+	Score int `json:"score"`
+	Total int `json:"total"`
+}
+
+// IQResponse returns the estimated IQ value and the simulated agents used.
+type IQResponse struct {
+	IQ     int           `json:"iq"`
+	Agents []utils.Agent `json:"agents"`
+}
+
+// IQHandler estimates an IQ-like value from a raw score.
+func IQHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Metodo non consentito", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req IQRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Dati non validi", http.StatusBadRequest)
+		return
+	}
+
+	if req.Total <= 0 || req.Score < 0 || req.Score > req.Total {
+		http.Error(w, "Dati non validi", http.StatusBadRequest)
+		return
+	}
+
+	agents := utils.GenerateAgents(30)
+	normalized := float64(req.Score) / float64(req.Total)
+	iq := utils.EstimateIQ(normalized, agents)
+
+	resp := IQResponse{IQ: iq, Agents: agents}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/handlers/sequence.go
+++ b/handlers/sequence.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/nicconuti/cognitive-api/utils"
+)
+
+// SequenceResponse wraps a list of sequence items with a timeout suggestion.
+type SequenceResponse struct {
+	Timeout int                  `json:"timeout"`
+	Items   []utils.SequenceItem `json:"items"`
+}
+
+// SequenceHandler serves numeric sequence reasoning items.
+// Example endpoint: /api/sequence?count=5
+func SequenceHandler(w http.ResponseWriter, r *http.Request) {
+	count := 5
+	if c := r.URL.Query().Get("count"); c != "" {
+		if v, err := strconv.Atoi(c); err == nil && v > 0 {
+			count = v
+		}
+	}
+
+	items := utils.GenerateSequenceSet(count)
+	resp := SequenceResponse{Timeout: 10, Items: items}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ func main() {
 	mux.HandleFunc("/api/test/results", handlers.ResultsHandler)
 	mux.HandleFunc("/api/stroop", handlers.StroopHandler)
 	mux.HandleFunc("/api/math", handlers.ArithmeticHandler)
+	mux.HandleFunc("/api/sequence", handlers.SequenceHandler)
+	mux.HandleFunc("/api/iq", handlers.IQHandler)
 	mux.HandleFunc("/api/pool", handlers.PoolHandler)
 
 	// Wrappa il mux con il middleware CORS

--- a/utils/agents.go
+++ b/utils/agents.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Agent represents a simulated comparison subject with a normalized score.
+type Agent struct {
+	Name  string  `json:"name"`
+	Score float64 `json:"score"`
+}
+
+// GenerateAgents creates n synthetic agents with scores following
+// a truncated normal distribution centered around typical test performance.
+// Scores are clipped to [0,1] and agent names are mostly unique.
+func GenerateAgents(n int) []Agent {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	names := []string{"Alex", "Jordan", "Casey", "Riley", "Morgan", "Taylor", "Chris", "Sam", "Jamie", "Drew", "Cameron", "Quinn", "Peyton", "Skyler", "Avery", "Hayden", "Charlie", "Dakota", "Emerson", "Harper"}
+	r.Shuffle(len(names), func(i, j int) { names[i], names[j] = names[j], names[i] })
+
+	agents := make([]Agent, n)
+	for i := 0; i < n; i++ {
+		var name string
+		if i < len(names) {
+			name = names[i]
+		} else {
+			name = fmt.Sprintf("Agent%02d", i-len(names)+1)
+		}
+
+		score := r.NormFloat64()*0.12 + 0.65
+		if score < 0 {
+			score = 0
+		}
+		if score > 1 {
+			score = 1
+		}
+
+		agents[i] = Agent{Name: name, Score: score}
+	}
+	return agents
+}
+
+// EstimateIQ returns an approximate IQ score for a given normalized test score
+// by comparing it with a population of agents. The IQ scale has mean 100 and
+// standard deviation 15.
+func EstimateIQ(userScore float64, agents []Agent) int {
+	if len(agents) == 0 {
+		return 100
+	}
+	if userScore < 0 {
+		userScore = 0
+	}
+	if userScore > 1 {
+		userScore = 1
+	}
+	// compute mean and standard deviation of agent scores
+	mean := 0.0
+	for _, a := range agents {
+		mean += a.Score
+	}
+	mean /= float64(len(agents))
+	variance := 0.0
+	for _, a := range agents {
+		diff := a.Score - mean
+		variance += diff * diff
+	}
+	sd := math.Sqrt(variance / float64(len(agents)))
+	if sd == 0 {
+		sd = 1
+	}
+	z := (userScore - mean) / sd
+	iq := int(math.Round(100 + z*15))
+	if iq < 40 {
+		iq = 40
+	}
+	if iq > 160 {
+		iq = 160
+	}
+	return iq
+}

--- a/utils/agents_test.go
+++ b/utils/agents_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import "testing"
+
+func TestGenerateAgents(t *testing.T) {
+	agents := GenerateAgents(5)
+	if len(agents) != 5 {
+		t.Fatalf("expected 5 agents, got %d", len(agents))
+	}
+	nameSet := make(map[string]bool)
+	total := 0.0
+	for _, a := range agents {
+		if a.Score < 0 || a.Score > 1 {
+			t.Errorf("score out of range: %f", a.Score)
+		}
+		if nameSet[a.Name] {
+			t.Errorf("duplicate name detected: %s", a.Name)
+		}
+		nameSet[a.Name] = true
+		total += a.Score
+	}
+	avg := total / float64(len(agents))
+	if avg < 0.5 || avg > 0.8 {
+		t.Errorf("unexpected mean score: %f", avg)
+	}
+}
+
+func TestEstimateIQ(t *testing.T) {
+	pop := GenerateAgents(20)
+	iq := EstimateIQ(0.6, pop)
+	if iq < 40 || iq > 160 {
+		t.Errorf("iq out of expected bounds: %d", iq)
+	}
+}

--- a/utils/pool.go
+++ b/utils/pool.go
@@ -12,6 +12,7 @@ const (
 	TestMemory     = "memory"
 	TestStroop     = "stroop"
 	TestArithmetic = "arithmetic"
+	TestSequence   = "sequence"
 )
 
 // PoolItem represents a single test to run with its type and count
@@ -35,6 +36,9 @@ func GeneratePool(level int) []PoolItem {
 	}
 	if level > 2 {
 		base = append(base, PoolItem{Type: TestStroop, Count: 5})
+	}
+	if level > 3 {
+		base = append(base, PoolItem{Type: TestSequence, Count: 5})
 	}
 
 	r.Shuffle(len(base), func(i, j int) { base[i], base[j] = base[j], base[i] })

--- a/utils/sequence.go
+++ b/utils/sequence.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"math/rand"
+	"time"
+)
+
+// SequenceItem defines a numeric series and the expected next value.
+type SequenceItem struct {
+	Series []int `json:"series"`
+	Answer int   `json:"answer"`
+}
+
+// GenerateSequence produces a single sequence item using common patterns.
+// Patterns include arithmetic progression, geometric progression and Fibonacci.
+func GenerateSequence() SequenceItem {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	pattern := r.Intn(3)
+
+	switch pattern {
+	case 0: // arithmetic progression
+		start := r.Intn(10)
+		diff := r.Intn(5) + 1
+		series := make([]int, 4)
+		for i := 0; i < 4; i++ {
+			series[i] = start + i*diff
+		}
+		answer := start + 4*diff
+		return SequenceItem{Series: series, Answer: answer}
+	case 1: // geometric progression
+		start := r.Intn(5) + 1
+		ratio := r.Intn(3) + 2
+		series := make([]int, 4)
+		value := start
+		for i := 0; i < 4; i++ {
+			series[i] = value
+			value *= ratio
+		}
+		answer := value
+		return SequenceItem{Series: series, Answer: answer}
+	default: // Fibonacci-like
+		a := r.Intn(5) + 1
+		b := r.Intn(5) + 1
+		series := []int{a, b}
+		for i := 2; i < 4; i++ {
+			series = append(series, series[i-1]+series[i-2])
+		}
+		answer := series[2] + series[3]
+		return SequenceItem{Series: series, Answer: answer}
+	}
+}
+
+// GenerateSequenceSet creates a list of sequence items.
+func GenerateSequenceSet(count int) []SequenceItem {
+	items := make([]SequenceItem, count)
+	for i := 0; i < count; i++ {
+		items[i] = GenerateSequence()
+	}
+	return items
+}

--- a/utils/sequence_test.go
+++ b/utils/sequence_test.go
@@ -1,0 +1,15 @@
+package utils
+
+import "testing"
+
+func TestGenerateSequenceSet(t *testing.T) {
+	items := GenerateSequenceSet(3)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	for _, it := range items {
+		if len(it.Series) != 4 {
+			t.Errorf("series length should be 4, got %d", len(it.Series))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- use a longer name list and unique names in GenerateAgents
- center the population distribution at 0.65 with lower sd
- extend GenerateAgents test for name uniqueness and mean score bounds

## Testing
- `go test ./...`


------
